### PR TITLE
nv ioctl pre/post handlers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 obj-m += mpu.o 
-mpu-objs := src/mpu_drv.o src/mpu_syscall_hook.o
+mpu-objs := src/mpu_drv.o src/mpu_syscall_hook.o src/mpu_ioctl.o
 
 all:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules

--- a/src/mpu_drv.c
+++ b/src/mpu_drv.c
@@ -22,6 +22,7 @@
 #include <linux/slab.h>
 
 #include "mpu_syscall_hook.h"
+#include "mpu_ioctl.h"
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Magnus <Magnusbackyard@live.com>");
@@ -55,9 +56,15 @@ static mpu_ctx_t *mpu_init_ctx(void)
   mpu_ctx_t *ctx;
   ctx = kzalloc(sizeof(mpu_ctx_t), GFP_KERNEL);
   if (ctx == NULL)
-    return ctx;
+    return NULL;
 
-  // TODO: init nv handlers
+  ctx->hs = mpu_init_nv_handlers();
+  if (ctx->hs == NULL)
+  {
+    kfree(ctx);
+    return NULL;
+  }
+
   return ctx;
 }
 
@@ -66,7 +73,7 @@ static void mpu_free_ctx(mpu_ctx_t *ctx)
   if (ctx == NULL)
     return;
 
-  // TODO: free nv handlers
+  mpu_free_nv_handlers(ctx->hs);
   kfree(ctx);
 }
 
@@ -111,6 +118,7 @@ static int __init mpu_drv_init(void)
     goto error;
 
   printk(KERN_INFO "mpu: mpu driver initialized.\n");
+  mpu_print_nv_handlers(mpu_ctx->hs);
   return 0;
 
 error:

--- a/src/mpu_ioctl.c
+++ b/src/mpu_ioctl.c
@@ -1,0 +1,251 @@
+//  MPU, A shim driver allows in-docker nvidia-smi showing correct process list without modify anything
+//  Copyright (C) 2021, Matpool
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along
+//  with this program; if not, write to the Free Software Foundation, Inc.,
+//  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include "mpu_ioctl.h"
+
+#include <linux/slab.h>
+#include <linux/pid.h>
+#include <linux/pid_namespace.h>
+#include <linux/uaccess.h>
+
+#include "mpu_nv.h"
+#include "mpu_syscall_hook.h"
+
+#define MAX_HANDLER_SLOTS 4
+
+struct mpu_nv_handlers_s
+{
+  int len;
+  mpu_nv_handler_t *vals;
+};
+
+static long nv_handle_dev_query(struct mpu_ioctl_call_s *ioctl_c, dev_t rdev, pid_t pid);
+
+static mpu_nv_handler_t handlers[] = {
+    {NV_IOCTL_DEV_QUERY, nv_handle_dev_query},
+};
+
+mpu_nv_handler_t *mpu_find_nv_handler(struct mpu_nv_handlers_s *hs, int cmd)
+{
+  int i = 0;
+  for (; i < hs->len; i++)
+  {
+    if (hs->vals[i].cmd == cmd)
+    {
+      return &hs->vals[i];
+    }
+  }
+  return ERR_PTR(-ENOENT);
+}
+
+struct mpu_nv_handlers_s *mpu_init_nv_handlers(void)
+{
+  struct mpu_nv_handlers_s *hs = kmalloc(sizeof(struct mpu_nv_handlers_s), GFP_KERNEL);
+  if (hs == NULL)
+  {
+    return NULL;
+  }
+
+  hs->vals = handlers;
+  hs->len = sizeof(handlers) / sizeof(handlers[0]);
+  return hs;
+}
+
+void mpu_free_nv_handlers(struct mpu_nv_handlers_s *hs)
+{
+  if (hs)
+    kfree(hs);
+}
+
+void mpu_print_nv_handlers(struct mpu_nv_handlers_s *hs)
+{
+  printk(KERN_INFO "mpu: %d nv handlers registered.\n", hs->len);
+}
+
+/**
+ * in-place update pids from global pids to current pid-ns pids
+ * rcu read protected
+ * @param pids len(pids) equals to off*cnt
+ */
+static void cast_vnr_pids(u32 *pids, u32 off, u32 cnt)
+{
+  u32 i;
+  pid_t pid;
+  struct pid *found = NULL;
+  struct pid_namespace *current_ns;
+
+  rcu_read_lock();
+  current_ns = task_active_pid_ns(current);
+  for (i = 0; i < cnt; i++, pids += off)
+  {
+    found = find_pid_ns(*pids, &init_pid_ns);
+    if (found)
+    {
+      pid = pid_nr_ns(found, current_ns);
+      *pids = (u32)pid;
+    }
+  }
+  rcu_read_unlock();
+}
+
+/**
+ * in-place update pids from current pid-ns pids to global pids
+ * rcu read protected
+ * @param pids len(pids) equals to off*cnt
+ */
+static void cast_nr_pids(u32 *pids, u32 off, u32 cnt)
+{
+  u32 i;
+  pid_t pid;
+  struct pid *found = NULL;
+  struct pid_namespace *current_ns;
+
+  rcu_read_lock();
+  current_ns = task_active_pid_ns(current);
+  for (i = 0; i < cnt; i++, pids += off)
+  {
+    if (*pids != 0)
+    {
+      if ((found = find_pid_ns(*pids, current_ns)) != NULL)
+      {
+        pid = pid_nr_ns(found, &init_pid_ns);
+        *pids = (u32)pid;
+      }
+    }
+  }
+  rcu_read_unlock();
+}
+
+static void print_pids(u32 *pids, u32 off, u32 cnt, const char *tag)
+{
+  u32 i;
+  for (i = 0; i < cnt; i++, pids += off)
+  {
+    printk(KERN_DEBUG "mpu: %s dump process pid %u\n", tag, *pids);
+  }
+}
+
+#define MPU_NV_CAST_PIDS_IMPL(ptr, list_type, item_type, cast)                     \
+  {                                                                                \
+    long ret = 0;                                                                  \
+    list_type pl;                                                                  \
+    u32 *pids = NULL; /* temp buffer for saving global pids or ns pids */          \
+    size_t len;        /* total items length in bytes */                            \
+    size_t elen;                                                                    \
+                                                                                   \
+    if (copy_from_user(&pl, ptr, sizeof(list_type)))                               \
+    {                                                                              \
+      printk(KERN_ERR "mpu: read NVML userspace type " #list_type " failed\n");    \
+      ret = -EFAULT;                                                               \
+      goto done;                                                                   \
+    }                                                                              \
+                                                                                   \
+    if (pl.cnt > 0)                                                                \
+    {                                                                              \
+      len = pl.cnt * sizeof(item_type);                                            \
+      elen = sizeof(item_type) / sizeof(u32);                                      \
+      pids = kmalloc(len, GFP_KERNEL);                                             \
+      if (pids == NULL)                                                            \
+      {                                                                            \
+        ret = -ENOMEM;                                                             \
+        goto done;                                                                 \
+      }                                                                            \
+                                                                                   \
+      if (copy_from_user(pids, ptr + offsetof(list_type, pl), len))                \
+      {                                                                            \
+        ret = -EFAULT;                                                             \
+        goto done;                                                                 \
+      }                                                                            \
+                                                                                   \
+      print_pids(pids, elen, pl.cnt, "before: " #item_type);                       \
+      cast(pids, elen, pl.cnt);                                                    \
+      print_pids(pids, 1, pl.cnt, "after: " #item_type);                           \
+                                                                                   \
+      if (copy_to_user(qm->u_ptr + offsetof(list_type, pl), pids, len))            \
+      {                                                                            \
+        printk(KERN_ERR "mpu: write NVML userspace type " #list_type " failed\n"); \
+        ret = -EFAULT;                                                             \
+      }                                                                            \
+    }                                                                              \
+  done:                                                                            \
+    if (pids)                                                                      \
+      kfree(pids);                                                                 \
+    return ret;                                                                    \
+  }
+
+static long nv_handle_query_nvml_processes(mpu_dev_query_t *qm)
+  MPU_NV_CAST_PIDS_IMPL(qm->u_ptr, mpu_nvml_process_list_t, u32, cast_vnr_pids)
+
+static long nv_handle_query_nvml_process_mem_pre(mpu_dev_query_t *qm)
+  MPU_NV_CAST_PIDS_IMPL(qm->u_ptr, mpu_nvml_process_mem_list_t, mpu_nvml_process_mem_item_t, cast_nr_pids)
+
+static long nv_handle_query_nvml_process_mem_post(mpu_dev_query_t *qm)
+  MPU_NV_CAST_PIDS_IMPL(qm->u_ptr, mpu_nvml_process_mem_list_t, mpu_nvml_process_mem_item_t, cast_vnr_pids)
+
+static long nv_handle_dev_query(struct mpu_ioctl_call_s *ioctl_c, dev_t rdev, pid_t pid)
+{
+  size_t arg_size = _IOC_SIZE(ioctl_c->cmd);
+  mpu_dev_query_t *arg_copy = NULL;
+  void *arg_ptr = (void *)ioctl_c->arg;
+  long ret = 0;
+
+  if (arg_size != sizeof(mpu_dev_query_t))
+  {
+    return mpu_call_ioctl(ioctl_c);
+  }
+
+  arg_copy = (mpu_dev_query_t *)kmalloc(arg_size, GFP_KERNEL);
+  if (arg_copy == NULL)
+  {
+    ret = -ENOMEM;
+    goto done;
+  }
+  else if (copy_from_user(arg_copy, arg_ptr, arg_size))
+  {
+    ret = -EINVAL;
+    goto done;
+  }
+
+  if (arg_copy->tag == 0x1f48)
+  {
+    ret = nv_handle_query_nvml_process_mem_pre(arg_copy);
+    if (ret < 0)
+      goto done;
+  }
+
+  ret = mpu_call_ioctl(ioctl_c);
+  if (ret < 0)
+    goto done;
+
+  switch (arg_copy->tag)
+  {
+  case 0xee4:
+    ret = nv_handle_query_nvml_processes(arg_copy);
+    break;
+  case 0x1f48:
+    ret = nv_handle_query_nvml_process_mem_post(arg_copy);
+    break;
+  }
+
+done:
+  if (ret < 0)
+    printk(KERN_ERR "mpu: mpu_dev_query_t failed with an error 0x%lx\n", -ret);
+  if (arg_copy)
+    kfree(arg_copy);
+
+  return ret;
+}

--- a/src/mpu_ioctl.h
+++ b/src/mpu_ioctl.h
@@ -1,0 +1,48 @@
+//  MPU, A shim driver allows in-docker nvidia-smi showing correct process list without modify anything
+//  Copyright (C) 2021, Matpool
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along
+//  with this program; if not, write to the Free Software Foundation, Inc.,
+//  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#ifndef __MPU_IOCTL_H__
+#define __MPU_IOCTL_H__
+
+#include "mpu_drv.h"
+
+typedef struct mpu_nv_handler_s
+{
+  int cmd;
+  /**
+   * @param pid request process global pid
+   */
+  long (*handle)(struct mpu_ioctl_call_s *ioctl_c, dev_t rdev, pid_t pid);
+} mpu_nv_handler_t;
+
+/**
+ * @param hs handlers
+ * @param cmd incoming request command
+ * @return valid handler or ERR_PTR
+ * and you should not retain the ptr returned from mpu_find_nv_handler
+ */
+extern mpu_nv_handler_t *mpu_find_nv_handler(struct mpu_nv_handlers_s *hs, int cmd);
+
+/**
+ * @return valid handlers or null when out of memory
+ */
+extern struct mpu_nv_handlers_s *mpu_init_nv_handlers(void);
+extern void mpu_free_nv_handlers(struct mpu_nv_handlers_s *hs);
+
+extern void mpu_print_nv_handlers(struct mpu_nv_handlers_s *hs);
+
+#endif // __MPU_IOCTL_H__

--- a/src/mpu_nv.h
+++ b/src/mpu_nv.h
@@ -49,7 +49,7 @@ typedef struct mpu_dev_query {
     u32   _1;
     u32   _2;
     void  * u_ptr  ALIGN_BYTES(8); // internal pointer
-    u32   size;
+    u32   tag;
 } mpu_dev_query_t;
 
 typedef struct mpu_nvml_process_list {


### PR DESCRIPTION
- query process list from global pid ns to virtual pid ns
- query process memory usage  from virtual pid ns to global pid ns in order to getting the correct memory usage
- cast global pid ns to virtual pid ns back when query process memory usage returned